### PR TITLE
Host assets on relative path

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -201,6 +201,10 @@ assets:
     js: { integrity: false } # true on JEKYLL_ENV=production
     css: { integrity: false } # true on JEKYLL_ENV=production
     img: { integrity: false } # true on JEKYLL_ENV=production
+  cdn:
+    baseurl: false
+    destination: false
+    url: null
   sources:
     - node_modules/uswds/dist
     - node_modules/netlify-cms/dist


### PR DESCRIPTION
Assets need to not be fetched via git branch path, which is what the default is with cf pages builds. 