### PR TITLE
Add Liquid expression to conditional, use string comparison

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -10,7 +10,7 @@ title: Search Results
 
   var urlParams = new URLSearchParams(window.location.search);
   var searchEndpoint = new URL("{{site.searchgov.endpoint}}/api/v2/search/i14y");
-  if (site.demo === true) {
+  if ( "{{site.demo}}" == "true" ) {
     params = { affiliate: "{{site.searchgov.affiliate}}", access_key: "{{ site.env.DEMO_SEARCH_ACCESS_KEY }}", query: urlParams.get('query') }  
   } else {
     params = { affiliate: "{{site.searchgov.affiliate}}", access_key: "{{ site.env.SEARCH_ACCESS_KEY }}", query: urlParams.get('query') }


### PR DESCRIPTION
New conditionals in the search setup broke functionality because of missing interpretation syntax. 

This PR adds it back and makes the if statement do a string instead of a boolean comparison.

Fix is working in demo branch and should fix production site when deployed. 