### PR TITLE
Add site alert to use in case of platform downtime

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -10,16 +10,19 @@ The home page uses wide.html layout, since it extends full width of page
 {% include meta.html %}
 
 <body{% if page.pageclass %} class="{{page.pageclass}}"{% endif %}>
-<section class="usa-site-alert usa-site-alert--info" aria-label="Site alert,">
-  <div class="usa-alert">
-    <div class="usa-alert__body">
-      <h3 class="usa-alert__heading">Temporary outage.</h3>
-      <p class="usa-alert__text">
-        The study's survey system is temporarily out of service. Please come back later. We apologize for the inconvenience.
-      </p>
+
+  {% if site.enable-banner-alert == true%}
+  <section class="usa-site-alert usa-site-alert--info" aria-label="Site alert,">
+    <div class="usa-alert">
+      <div class="usa-alert__body">
+        <h3 class="usa-alert__heading">Temporary outage.</h3>
+        <p class="usa-alert__text">
+          The study's survey system is temporarily out of service. Please come back later. We apologize for the inconvenience.
+        </p>
+      </div>
     </div>
-  </div>
-</section>
+  </section>
+  {% endif %}
 
   {% include header.html %}
 


### PR DESCRIPTION
## Rationale
When the platform is down due to maintenance, updates, or outages we need to alert potential new users of the issue. 

We use the [USWDS Site Alert component](https://designsystem.digital.gov/components/site-alert/#site-alert-guidance) to display a banner at the top of the page alerting users that they system is not currently operational (see preview below).

## Preview 
<img width="1273" alt="Landing Page Site Alert Outage Banner" src="https://github.com/GSA-TTS/identity-idva-docs/assets/59618057/66a81ee7-90f3-4508-b754-3d6de17b61d1">

## Configuration
The `enable-banner-alert: true` key setting in the cloud pages dashboard controls whether the banner is displayed or not.

<img width="794" alt="Equity Study Landing Page enable-banner-alert cloud pages setting" src="https://github.com/GSA-TTS/identity-idva-docs/assets/59618057/9cdf0161-0406-4e4b-8007-0195bd89f166">

