### PR TITLE
Add timeout config to htmlproofer script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "reset": "npx rimraf .git",
     "start": "bundle exec jekyll serve --livereload",
     "start-detached": "bundle exec jekyll serve --detach",
-    "htmlproofer": "bundle exec htmlproofer --no-enforce-https --allow-missing-href _site",
+    "htmlproofer": "bundle exec htmlproofer --typhoeus='{\"timeout\": 60}' --no-enforce-https --allow-missing-href _site",
     "pa11y-ci:sitemap": "pa11y-ci --sitemap http://localhost:4000/sitemap.xml --sitemap-exclude \"/*.pdf\"  --sitemap-exclude \"/admin\""
   },
   "dependencies": {


### PR DESCRIPTION
Fixes problem with NIST pdf link causing consistent test failure due to timeouts (Build and test Jekyll job).

- sets timeout to 60 seconds
